### PR TITLE
BUGBOT v2: concise persona-driven review analysis

### DIFF
--- a/BUGBOT.md
+++ b/BUGBOT.md
@@ -1,23 +1,12 @@
 # BUGBOT — mock-publisher-dotnet6
-> Auto-generated from PR review analysis. Do not edit manually.
-> Last updated: 2026-03-23
 
-## Overview
+> Watches for routing defects, controller correctness, and configuration hygiene in this .NET 6 mock publisher service.
 
-Insufficient review data to identify recurring patterns. Only 2 inline review comments were found across 5 PRs, both addressing the same isolated issue (a double slash in a route definition). No subdirectory-level BUGBOT files have been created.
+## Code Quality
+- **Duplicate route segments**: Check `[Route]` attributes for double slashes — e.g. `/mocker//health` instead of `/mocker/health`.
+- **Malformed path attributes**: Verify all route strings have no trailing slashes or typos before merging.
 
-## Inline Comment Summary
-
-| File | Comment | Resolved |
-|------|---------|---------|
-| `WebhookTemplateCS/src/controllers/health/HealthController.cs` | Double slash in route path: `[Route("/mocker//health")]` should be `[Route("/mocker/health")]` | Yes (fixed in follow-up commit) |
-
-## Most Reviewed Areas
-
-Only one file received inline comments across all PRs — insufficient data for a meaningful ranking.
-
-## Action Items
-
-- [ ] Audit all controller route attributes for duplicate or malformed path segments
-- [ ] Add more thorough code review to PRs (most PRs were approved with no inline feedback)
-- [ ] Consider adding automated route validation or linting to CI
+## Checklist
+- [ ] All controller `[Route]` attributes are free of double or trailing slashes
+- [ ] Route paths match the intended API surface exactly
+- [ ] CI includes a route validation or lint step to catch path defects automatically


### PR DESCRIPTION
## BUGBOT v2 — Improved Analysis Files

Replaces the previous verbose BUGBOT.md files with a concise, persona-driven format:
- Short persona block per file declaring what the BUGBOT watches
- One-line bullet rules (no PR quotes, no frequency tables, no historical examples)
- Actionable checklist at the end
- Max 60 lines (root) / 30 lines (subdirectory)

Generated by BUGBOT improve-bugbot.sh